### PR TITLE
ci: run TypeScript typecheck in build workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Run TypeScript type checking
+      run: npm run typecheck
+
     - name: Run tests with coverage
       run: npm run test:coverage
 


### PR DESCRIPTION
## Problem

`.github/workflows/build-and-test.yml` runs only `npm run test:coverage`. It never runs `tsc --noEmit`, even though `package.json` has defined `"typecheck": "tsc --noEmit"` all along.

That is a real hole, not a theoretical one. This repo is strict-mode TypeScript, and its tests **mock the OpenAI and Anthropic SDKs**. Mocks satisfy the test suite regardless of what the real SDK types look like, so a dependency bump that breaks an SDK's type surface sails through CI green while the code no longer compiles.

This was just demonstrated in practice. Ten Dependabot PRs — including `openai` 6 → 7 and `@anthropic-ai/sdk` 0.95 → 0.115, both major/breaking type-surface changes — all showed green CI. The green told us nothing about type safety. Every one of them had to be typechecked by hand before it was safe to merge.

## Change

One step, three lines:

```diff
     - name: Install dependencies
       run: npm ci
 
+    - name: Run TypeScript type checking
+      run: npm run typecheck
+
     - name: Run tests with coverage
       run: npm run test:coverage
```

It sits after `Install dependencies` and before `Run tests with coverage`, so type errors fail fast ahead of the slower test job. Nothing else in the workflow is touched — no reordering, no action-version bumps, no reformatting.

## Test plan

- [x] `npm ci` succeeds on this branch
- [x] `npm run typecheck` passes on this branch — the new step will go **green**, not red, so this PR does not smuggle in a pre-existing type failure
- [x] Workflow YAML parses cleanly; step list confirms the new step lands at index 3, between `Install dependencies` (2) and `Run tests with coverage` (4)
- [x] `git diff origin/main --name-only` reports exactly one changed file: `.github/workflows/build-and-test.yml`
- [x] CI on this PR shows the **Run TypeScript type checking** step executing and passing — [run 31186574962](https://github.com/bostonaholic/reflect/actions/runs/31186574962) green, step order confirmed: `Install dependencies` → `Run TypeScript type checking` → `Run tests with coverage`

## Follow-up (not in this PR)

Now that typecheck runs on every PR, the next Dependabot SDK bump gets a genuine type-safety signal instead of a mock-shaped one. Worth considering separately: making this step a required status check in branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdVm1JeCHmzX41x7aFuNEo
